### PR TITLE
add TOS and PP links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ node_modules
 
 # Easy way to create temporary files/folders that won't accidentally be added to git
 *.local.*
+
+# Ignore Mac DS_Store files
+.DS_Store

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -8,6 +8,7 @@ import {
 } from '@remix-run/node'
 import {
 	Form,
+	Link,
 	useActionData,
 	useFormAction,
 	useLoaderData,
@@ -219,8 +220,19 @@ export default function OnboardingPage() {
 					<CheckboxField
 						labelProps={{
 							htmlFor: fields.agreeToTermsOfServiceAndPrivacyPolicy.id,
-							children:
-								'Do you agree to our Terms of Service and Privacy Policy?',
+							children: (
+								<>
+									Do you agree to our{' '}
+									<Link to="/tos" target="_blank" className="underline">
+										Terms of Service
+									</Link>{' '}
+									and{' '}
+									<Link to="/privacy" target="_blank" className="underline">
+										Privacy Policy
+									</Link>
+									?
+								</>
+							),
 						}}
 						buttonProps={conform.input(
 							fields.agreeToTermsOfServiceAndPrivacyPolicy,


### PR DESCRIPTION
I added links to the already existing Terms of Service and Privacy Policy routes in the onboarding form. I also added .DS_Store to .gitignore for Mac-based developers. 
