### PR TITLE
Mobilize onboarding

### DIFF
--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -21,7 +21,7 @@ const buttonVariants = cva(
 			},
 			size: {
 				default: 'h-10 px-4 py-2',
-				wide: 'px-24 py-5',
+				wide: 'px-12 py-5',
 				sm: 'h-9 rounded-md px-3',
 				lg: 'h-11 rounded-md px-8',
 				pill: 'px-12 py-3 leading-3',

--- a/app/routes/_auth+/forgot-password/index.tsx
+++ b/app/routes/_auth+/forgot-password/index.tsx
@@ -138,7 +138,7 @@ export default function ForgotPasswordRoute() {
 				<forgotPassword.Form
 					method="POST"
 					{...form.props}
-					className="mx-auto mt-16 min-w-[368px] max-w-sm"
+					className="mx-auto mt-16 w-full max-w-sm"
 				>
 					<div>
 						<Field

--- a/app/routes/_auth+/forgot-password_.verify.tsx
+++ b/app/routes/_auth+/forgot-password_.verify.tsx
@@ -160,7 +160,7 @@ export default function ForgotPasswordVerifyRoute() {
 			<div className="flex flex-col justify-center">
 				<>
 					<div className="text-center">
-						<h1 className="text-h1">Check your email</h1>
+						<h1 className="text-4xl sm:text-h1">Check your email</h1>
 						<p className="mt-3 text-body-md text-muted-foreground">
 							We've sent you a code to verify your password reset.
 						</p>
@@ -168,7 +168,7 @@ export default function ForgotPasswordVerifyRoute() {
 					<Form
 						method="POST"
 						{...form.props}
-						className="mx-auto mt-16 min-w-[368px] max-w-sm"
+						className="mx-auto mt-16 w-full max-w-sm"
 					>
 						<Field
 							labelProps={{

--- a/app/routes/_auth+/onboarding.tsx
+++ b/app/routes/_auth+/onboarding.tsx
@@ -165,7 +165,7 @@ export default function OnboardingPage() {
 		<div className="container flex min-h-full flex-col justify-center pb-32 pt-20">
 			<div className="mx-auto w-full max-w-lg">
 				<div className="flex flex-col gap-3 text-center">
-					<h1 className="text-h1">Welcome aboard!</h1>
+					<h1 className="text-4xl sm:text-h1">Welcome aboard!</h1>
 					<p className="text-body-md text-muted-foreground">
 						Please enter your details.
 					</p>
@@ -173,7 +173,7 @@ export default function OnboardingPage() {
 				<Spacer size="xs" />
 				<Form
 					method="POST"
-					className="mx-auto min-w-[368px] max-w-sm"
+					className="mx-auto w-full max-w-sm"
 					{...form.props}
 				>
 					<Field

--- a/app/routes/_auth+/reset-password.tsx
+++ b/app/routes/_auth+/reset-password.tsx
@@ -119,7 +119,7 @@ export default function ResetPasswordPage() {
 			</div>
 			<Form
 				method="POST"
-				className="mx-auto mt-16 min-w-[368px] max-w-sm"
+				className="mx-auto mt-16 w-full max-w-sm"
 				{...form.props}
 			>
 				<Field

--- a/app/routes/_auth+/signup/index.tsx
+++ b/app/routes/_auth+/signup/index.tsx
@@ -139,14 +139,14 @@ export default function SignupRoute() {
 	return (
 		<div className="container mx-auto flex flex-col justify-center pb-32 pt-20">
 			<div className="text-center">
-				<h1 className="text-h1">Let's saddle up!</h1>
+				<h1 className="text-4xl sm:text-h1">Let's saddle up!</h1>
 				<p className="mt-3 text-body-md text-muted-foreground">
 					Please enter your email.
 				</p>
 			</div>
 			<Form
 				method="POST"
-				className="mx-auto mt-16 min-w-[368px] max-w-sm"
+				className="mx-auto mt-16 w-full max-w-sm"
 				{...form.props}
 			>
 				<Field

--- a/app/routes/_auth+/signup_.verify.tsx
+++ b/app/routes/_auth+/signup_.verify.tsx
@@ -135,7 +135,7 @@ export default function SignupVerifyRoute() {
 	return (
 		<div className="container mx-auto flex flex-col justify-center pb-32 pt-20">
 			<div className="text-center">
-				<h1 className="text-h1">Check your email</h1>
+				<h1 className="text-4xl sm:text-h1">Check your email</h1>
 				<p className="mt-3 text-body-md text-muted-foreground">
 					We've sent you a code to verify your email address.
 				</p>
@@ -143,7 +143,7 @@ export default function SignupVerifyRoute() {
 
 			<Form
 				method="POST"
-				className="mx-auto mt-16 min-w-[368px] max-w-sm"
+				className="mx-auto mt-16 w-full max-w-sm"
 				{...form.props}
 			>
 				<Field

--- a/app/routes/_marketing+/index.tsx
+++ b/app/routes/_marketing+/index.tsx
@@ -23,8 +23,8 @@ export default function Index() {
 							/>
 							<div className="absolute inset-0 bg-[color:rgba(27,167,254,0.5)] mix-blend-multiply" />
 						</div>
-						<div className="lg:pt-18 relative flex flex-col items-center px-4 pb-8 pt-8 sm:px-6 sm:pb-14 sm:pt-16 lg:px-8 lg:pb-20">
-							<h1 className="text-center text-mega font-extrabold tracking-tight sm:text-8xl lg:text-9xl">
+						<div className="relative flex flex-col items-center px-4 pb-8 pt-8 sm:px-6 sm:pb-14 sm:pt-16 lg:pt-18 lg:px-8 lg:pb-20">
+							<h1 className="text-center font-extrabold tracking-tight text-5xl sm:text-8xl lg:text-9xl">
 								<a
 									className="block uppercase text-brand-secondary drop-shadow-md"
 									href="https://www.thebarnaz.com"


### PR DESCRIPTION
Overview: Improved onboarding experience for mobile devices (down to 320x568, iPhone 5/SE), preventing unnecessary text and form input overflow.

Button padding reduced to prevent strange button text formatting on mobile while still being very large buttons.

Minimum widths on forms removed to prevent overflow on 320 width screens. `w-full` added to remain responsive and fill space on larger screens up to the `max-w-sm` that was already set.

Onboarding and Marketing/Index page H1s reduced in size on sub-640px screens.