### PR TITLE
always show X on toasts

### DIFF
--- a/app/components/ui/toast.tsx
+++ b/app/components/ui/toast.tsx
@@ -74,7 +74,11 @@ const ToastClose = React.forwardRef<
 	<ToastPrimitives.Close
 		ref={ref}
 		className={cn(
-			'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+			`absolute right-2 top-2 rounded-md p-1 text-foreground/50
+			hover:text-foreground 
+			focus:outline-none focus:ring-2 
+			group-hover:opacity-100 
+			group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600`,
 			className,
 		)}
 		toast-close=""


### PR DESCRIPTION
Makes it clear that you can close toasts without having to hover and allows mobile users to close toasts since they cannot hover. 