### PR TITLE
Add some whitespace to Volunteer Registration dialog

### DIFF
--- a/app/routes/calendar+/index.tsx
+++ b/app/routes/calendar+/index.tsx
@@ -344,7 +344,7 @@ function RegistrationDialogue({ selectedEventId, events }: RegistrationProps) {
 					defaultValue={volunteerTypes[volunteerTypeIdx].field}
 					disabled={isRegistered}
 				>
-					<ul className="">
+					<ul className="pb-4">
 						{volunteerTypes.map(volunteerType => {
 							const spotsLeft = calEvent[`${volunteerType.field}Req`]-calEvent[volunteerType.field].length
 
@@ -401,7 +401,7 @@ function RegistrationDialogue({ selectedEventId, events }: RegistrationProps) {
 				</RadioGroup>
 				{!isRegistered ? null : (
 					<>
-						<div>
+						<div className="pb-4">
 							<input type="hidden" name="role" value={registeredAs.field} />
 							You are registered to volunteer in this event as one of the{' '}
 							{registeredAs.displayName}.


### PR DESCRIPTION
Added space below volunteer options, and space below the 'Registered' message to lessen visual clutter. 

pb-4 is used within the form for visual consistency with the parent dialog element's gap-4.