### PR TITLE
Calendar Event Registration Testing 

### DIFF
--- a/tests/e2e/calendar.test.ts
+++ b/tests/e2e/calendar.test.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import invariant from 'tiny-invariant'
 import {
     expect,
+    hideCurrentMonthEvents,
     insertNewUser,
     test
 } from '../playwright-utils.ts'
@@ -30,7 +31,9 @@ test('registering for an event', async ({ page }) => {
         email: `${user.email}`,
     }
 
-    // Create fake event
+    // Event Creation setup
+    hideCurrentMonthEvents()
+
     const eventDate = new Date()
     eventDate.setDate(eventDate.getDate() + 2)
     const eventData = await createEvent(eventDate)

--- a/tests/e2e/calendar.test.ts
+++ b/tests/e2e/calendar.test.ts
@@ -1,0 +1,97 @@
+import { faker } from '@faker-js/faker'
+import invariant from 'tiny-invariant'
+import {
+    expect,
+    insertNewUser,
+    test
+} from '../playwright-utils.ts'
+import { createEvent } from 'tests/db-utils.ts'
+import { prisma } from '~/utils/db.server.ts'
+import { readEmail } from 'tests/mocks/utils.ts'
+import { siteEmailAddress } from '~/data.ts'
+
+const dateRegex = /On: (?<date>[A-Z][a-z]+ [0-9]+[a-z]+, [0-9]+)/
+function extractDate (text: string) {
+    const match = text.match(dateRegex)
+    return match?.groups?.date
+}
+
+test('registering for an event', async ({ page }) => {
+
+    // Create fake user
+    const password = faker.internet.password()
+    const user = await insertNewUser({password})
+    invariant(user.name, 'User name not found')
+
+    //email
+    const confirmationEmail = {
+        name: `${user.name}`,
+        username: `${user.username}`,
+        email: `${user.email}`,
+    }
+
+    // Create fake event
+    const eventDate = new Date()
+    eventDate.setDate(eventDate.getDate() + 2)
+    const eventData = await createEvent(eventDate)
+
+    const event = await prisma.event.create({
+        data: {
+            ...eventData,
+        },
+    })
+
+    // Login to page
+    await page.goto('/login')
+    await page.getByRole('textbox', { name: /username/i })
+    .fill(user.username)
+    await page.getByLabel(/^password$/i).fill(password)
+    await page.getByRole('button', { name: /log in/i })
+    .click()
+    
+    await expect(page).toHaveURL(`/`)
+    await expect(page.getByRole('link', { name: user.name }))
+    .toBeVisible()
+
+    // Navigate to calendar
+    await page.getByRole('link', { name: 'Calendar', exact: true })
+    .click()
+    await expect(page).toHaveURL(`/calendar`)
+    await expect(page.getByRole('link', { name: user.name }))
+    .toBeVisible()
+
+    // Navigate to event
+    // @TODO: select event drop when +3 or more events
+    await page.getByRole('row')
+    .filter({has: page.getByRole('cell', { name: event.start.getDate().toString()})})
+    .getByTitle(event.title)
+    .click()
+    await expect(page.getByRole('button', { name: 'Register', exact: true}))
+    .toBeVisible()
+
+    // Register for event
+    // @TODO: select an avaliable role
+    await page.getByRole('button', { name: 'Register', exact: true})
+    .click()
+    await expect(page.getByRole('button', { name: 'Unregister', exact: true}))
+    .toBeVisible()
+
+    // intercept mock email
+    const email = await readEmail(confirmationEmail.email)
+    invariant(email, 'Email not found')
+    expect(email.to).toBe(confirmationEmail.email)
+    expect(email.from).toBe(siteEmailAddress)
+    expect(email.subject).toBe('Event Registration Notification')
+    
+    const reservationDate = extractDate(email.text)
+    invariant(reservationDate, 'Date not found')
+
+    //TODO: check reseveration date against event.Start?
+
+    //Clean up
+    await prisma.event.delete({
+        where: {
+            id: event.id,
+        },
+    })
+})

--- a/tests/e2e/calendar.test.ts
+++ b/tests/e2e/calendar.test.ts
@@ -117,12 +117,15 @@ test('registering for an event', async ({ page }) => {
     invariant(reservationDate, 'Date not found')
     expect(reservationDate).toBe(format(event.start, 'MMMM do, Y'))
     
+    /*
+        Preparation for email checks on admin
     if(confirmationEmailAdmin.length) {
         for(let e of confirmationEmailAdmin) {
             let adminEmail = await readEmail(e.email)
             invariant(adminEmail, 'Admin email not found')
         }
     }
+    */
 
     //Clean up
     await prisma.event.delete({


### PR DESCRIPTION
<!-- Summary: Added testing for user registration  -->

for #4
Draft PR for users registering for events on calendar.
This is testing if a user is able to register an event on the calendar ~2days ahead. 
current test will hide every event other than the one created.

later plans for testing to check if the user has ***required*** roles to register as discussed in slack

current testing plan:
1. log in
2. navigate to calendar
3. navigate to event
4. register
5. intercept email
6. intercept admin email

created hide events function in playwright-utils.ts to hide current month events, probably will be further expanded/refined.