### PR TITLE
Prevent placeholder popover

### DIFF
--- a/app/routes/calendar+/$eventId.tsx
+++ b/app/routes/calendar+/$eventId.tsx
@@ -327,7 +327,7 @@ function VolunteerListItem({
 					'border-1 border border-dashed border-primary opacity-50 dark:bg-slate-800',
 			)}
 		>
-			<VolunteerInfoPopover volunteer={user}>
+			{isPlaceholder ? (
 				<div className="flex w-1/3 items-center gap-2">
 					<img
 						className="h-14 w-14 rounded-full object-cover"
@@ -336,7 +336,18 @@ function VolunteerListItem({
 					/>
 					{user.name}
 				</div>
-			</VolunteerInfoPopover>
+			) : (
+				<VolunteerInfoPopover volunteer={user}>
+					<div className="flex w-1/3 items-center gap-2">
+						<img
+							className="h-14 w-14 rounded-full object-cover"
+							alt={user.name ?? user.username}
+							src={getUserImgSrc(user.imageId)}
+						/>
+						{user.name}
+					</div>
+				</VolunteerInfoPopover>
+			)}
 			<Icon className="text-body-xl" name="arrow-right" />
 
 			<div className="flex items-center gap-2">


### PR DESCRIPTION
Small fix removes the popover for volunteer placeholder data on the $eventId page. 

Before: clicking on "No one yet" opened a popover with placeholder profile data. You could also click profile which would take you to a fake placeholder profile. This is unnecessary and could be confusing.

Now: It appears the same but clicking on "No one yet" does nothing. This could later to changed to add an invite functionality etc etc. 