### PR TITLE
Fix loading and editing roles

### DIFF
--- a/app/routes/admin+/_users+/users.edit.$userId.tsx
+++ b/app/routes/admin+/_users+/users.edit.$userId.tsx
@@ -99,6 +99,19 @@ export async function action({ request, params }: DataFunctionArgs) {
 		isLessonAssistant,
 	} = submission.value
 
+	const roleConnectArray = []
+	const roleDisconnectArray = []
+	if (isHorseLeader) {
+		roleConnectArray.push({ name: 'horseLeader' })
+	} else {
+		roleDisconnectArray.push({ name: 'horseLeader' })
+	}
+	if (isLessonAssistant) {
+		roleConnectArray.push({ name: 'lessonAssistant'})
+	} else {
+		roleDisconnectArray.push({ name: 'lessonAssistant'})
+	}
+
 	const updatedUser = await prisma.user.update({
 		where: { id: params.userId },
 		data: {
@@ -110,8 +123,8 @@ export async function action({ request, params }: DataFunctionArgs) {
 			yearsOfExperience: yearsOfExperience ?? null,
 			instructor: isInstructor,
 			roles: {
-				[isHorseLeader ? 'connect' : 'disconnect']: { name: 'horseLeader' },
-				[isLessonAssistant ? 'connect' : 'disconnect']: { name: 'lessonAssistant' },
+				connect: roleConnectArray,
+				disconnect: roleDisconnectArray,
 			},
 		},
 	})
@@ -175,11 +188,12 @@ export default function EditUser() {
 
 	let isLessonAssistant = false
 	let isHorseLeader = false
+	let isInstructor = data.user?.instructor ?? false
 	for (const role of data.user?.roles) {
-		if (role.name == 'lessonAssistant') {
+		if (role.name === 'lessonAssistant') {
 			isLessonAssistant = true
 		}
-		if (role.name == 'horseLeader') {
+		if (role.name === 'horseLeader') {
 			isHorseLeader = true
 		}
 	}
@@ -273,9 +287,12 @@ export default function EditUser() {
 									htmlFor: fields.isInstructor.id,
 									children: 'Instructor',
 								}}
-								buttonProps={conform.input(fields.isInstructor, {
-									type: 'checkbox',
-								})}
+								buttonProps={{
+									...conform.input(fields.isInstructor, {
+										type: 'checkbox',
+									}),
+									defaultChecked: isInstructor,
+								}}
 								errors={fields.isInstructor.errors}
 							/>
 							<CheckboxField

--- a/app/routes/admin+/_users+/users.tsx
+++ b/app/routes/admin+/_users+/users.tsx
@@ -52,7 +52,7 @@ export const columns: ColumnDef<UserWithRole>[] = [
 		cell: ({ row }) => {
 			const s = row.getValue('phone') as string
 			const formatted = s ? `${s.slice(0,3)}-${s.slice(3,6)}-${s.slice(6,10)}` : null
-			return <div>{formatted}</div>
+			return formatted
 		}
 	},
 	{
@@ -61,46 +61,41 @@ export const columns: ColumnDef<UserWithRole>[] = [
 		cell: ({ row }) => {
 			const timeStamp = new Date(row.getValue('lastLogin'))
 			const formatted = formatRelative(timeStamp, new Date())
-			return <div>{formatted}</div>
+			return formatted
 		},
 	},
 	{
 		accessorKey: 'instructor',
 		header: 'instructor',
 		cell: ({ row }) => {
-			return <div>{row.original.instructor ? 'Yes' : 'No'}</div>
+			return row.original.instructor ? 'Yes' : 'No'
 		},
 	},
 	{
-		accessorKey: 'admin',
 		header: 'admin',
-		cell: ({ row }) => {
-			const isAdmin = row.original.roles.find(r => r.name == 'admin')
-			return <div>{isAdmin ? 'Yes' : 'No'}</div>
+		accessorFn: (row) => {
+			const hasRole = row.roles.find(r => r.name === 'admin')
+			return hasRole ? 'Yes' : 'No'
 		},
 	},
 	{
-		accessorKey: 'lessonAssistant',
 		header: 'lesson assistant',
-		enableResizing: true,
-		maxSize: 1,
-		cell: ({ row }) => {
-			const hasRole = row.original.roles.find(r => r.name == 'lessonAssistant')
-			return <div>{hasRole ? 'Yes' : 'No'}</div>
+		accessorFn: (row) => {
+			const hasRole = row.roles.find(r => r.name === 'lessonAssistant')
+			return hasRole ? 'Yes' : 'No'
 		},
 	},
 	{
-		accessorKey: 'horseLeader',
 		header: 'horse leader',
-		cell: ({ row }) => {
-			const hasRole = row.original.roles.find(r => r.name == 'horseLeader')
-			return <div>{hasRole ? 'Yes' : 'No'}</div>
+		accessorFn: (row) => {
+			const hasRole = row.roles.find(r => r.name === 'horseLeader')
+			return hasRole ? 'Yes' : 'No'
 		},
 	},
 	{
 		id: 'actions',
 		cell: ({ row }) => {
-			const isAdmin = row.original.roles.find(r => r.name == 'admin')
+			const isAdmin = row.original.roles.find(r => r.name === 'admin')
 			return (
 				<DropdownMenu>
 					<DropdownMenuTrigger asChild>

--- a/app/routes/admin+/_users+/users.tsx
+++ b/app/routes/admin+/_users+/users.tsx
@@ -72,7 +72,7 @@ export const columns: ColumnDef<UserWithRole>[] = [
 		},
 	},
 	{
-		accessorKey: 'roles',
+		accessorKey: 'admin',
 		header: 'admin',
 		cell: ({ row }) => {
 			const isAdmin = row.original.roles.find(r => r.name == 'admin')
@@ -80,7 +80,7 @@ export const columns: ColumnDef<UserWithRole>[] = [
 		},
 	},
 	{
-		accessorKey: 'roles',
+		accessorKey: 'lessonAssistant',
 		header: 'lesson assistant',
 		enableResizing: true,
 		maxSize: 1,
@@ -90,7 +90,7 @@ export const columns: ColumnDef<UserWithRole>[] = [
 		},
 	},
 	{
-		accessorKey: 'roles',
+		accessorKey: 'horseLeader',
 		header: 'horse leader',
 		cell: ({ row }) => {
 			const hasRole = row.original.roles.find(r => r.name == 'horseLeader')


### PR DESCRIPTION
Updated logic so that checkboxes show correct initial status for the various roles on the edit user page. 

Updated the role connect and disconnect logic to allow for multiple roles. 

Equality operator (==) swapped for Strict equality operator (===) for _slight_ performance gains and more predictable behavior. 

accessorKeys changed to remove console errors:
> Warning: Encountered two children with the same key, `roles`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.