### PR TITLE
Prevent cooldown horse from being registered

### DIFF
--- a/app/components/listboxes.tsx
+++ b/app/components/listboxes.tsx
@@ -35,7 +35,7 @@ export function HorseListbox({
 	const [selected, setSelected] = useState(initialValues)
 
 	return (
-		<Listbox value={selected} onChange={setSelected} name={name} multiple>
+		<Listbox value={selected} by="id" onChange={setSelected} name={name} multiple>
 			<div className="relative mt-1">
 				<div className={''}>
 					<Listbox.Button className={listboxButtonClassName}>
@@ -67,7 +67,7 @@ export function HorseListbox({
 									<>
 										<span
 											className={`block truncate 
-											${selected ? 'font-medium' : 'font-normal'}`}
+											${selected ? 'font-semibold' : 'font-normal'}`}
 										>
 											{horse.name}
 										</span>

--- a/app/routes/admin+/_horses+/horses.edit.$horseId.tsx
+++ b/app/routes/admin+/_horses+/horses.edit.$horseId.tsx
@@ -185,10 +185,7 @@ export default function EditHorse() {
 			: false
 		: data.horse?.cooldown
 	const [cooldownChecked, setCooldownChecked] = useState(cooldown)
-	console.log('actionData', actionData)
 	const conflictEvents = actionData?.conflictEvents ?? null
-	const testDate = format(new Date('2023-06-05'), 'h:mmaaa MMMM do, yyyy')
-	console.log('testDate', testDate)
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>

--- a/app/routes/calendar+/$eventId.tsx
+++ b/app/routes/calendar+/$eventId.tsx
@@ -146,8 +146,10 @@ export default function () {
 			<section className="h-fit pr-2 md:sticky md:top-20 md:w-2/5">
 				<h1 className="text-h2 uppercase">Event Details</h1>
 				<Card className="px-4 py-6">
-					<div className="flex items-center justify-between">
-						<h2 className="text-2xl font-bold">{event.title}</h2>
+					<div className="flex flex-wrap items-center justify-between">
+						<h2 className="text-2xl font-bold">
+							{event.title}
+						</h2>
 						<Button asChild className="" variant="default" size="sm">
 							<Link to="edit">Edit</Link>
 						</Button>
@@ -406,7 +408,7 @@ function HorseInfoPopover({ children, horse }: HorseInfoPopoverProps) {
 			<PopoverContent side="bottom">
 				<div className="text-xl">{horse.name}</div>
 				<img
-					className="h-52 w-52 rounded-full object-cover mx-auto"
+					className="mx-auto h-52 w-52 rounded-full object-cover"
 					alt="horse"
 					src={getHorseImgSrc(horse.imageId)}
 				/>
@@ -445,7 +447,7 @@ function VolunteerInfoPopover({
 					</Link>
 				</div>
 				<img
-					className="h-52 w-52 rounded-full object-cover mx-auto"
+					className="mx-auto h-52 w-52 rounded-full object-cover"
 					alt="horse"
 					src={getHorseImgSrc(volunteer.imageId)}
 				/>
@@ -466,10 +468,8 @@ function VolunteerInfoPopover({
 					{volunteer.yearsOfExperience}
 				</div>
 				<div>
-					<span className="text-xs font-bold uppercase">
-						Phone Number:{' '}
-					</span>
-					{ formatPhone(volunteer.phone) }
+					<span className="text-xs font-bold uppercase">Phone Number: </span>
+					{formatPhone(volunteer.phone)}
 				</div>
 				<div>
 					<span className="text-xs font-bold uppercase">Notes: </span>


### PR DESCRIPTION
![Screen Shot 2023-08-09 at 13 49 52](https://github.com/opportunity-hack/evs/assets/92223355/d60d0fd5-a218-472e-a772-402fb20556ea)

When creating a new event, a list of horses that have cooldown conflicts during the startdate are displayed in a toast. 

Ideally there would be a red border around the listbox on an error but that can wait until later IMO.

Still need to add cooldown checking to the Edit Event Details dialog.