### PR TITLE
Show dialog close even when event has passed

### DIFF
--- a/app/routes/calendar+/index.tsx
+++ b/app/routes/calendar+/index.tsx
@@ -499,11 +499,11 @@ function RegistrationDialogue({ selectedEventId, events }: RegistrationProps) {
 									Register
 								</Button>
 							)}
-							<DialogClose autoFocus={false} />
 						</DialogFooter>
 					</registrationFetcher.Form>
 				</>
 			)}
+			<DialogClose autoFocus={false} />
 		</DialogContent>
 	)
 }


### PR DESCRIPTION
Moves DialogClose so it is rendered even when event has passed.