### PR TITLE
Add multiple date events 🐎🐎🐎

### DIFF
--- a/app/components/forms.tsx
+++ b/app/components/forms.tsx
@@ -4,6 +4,16 @@ import { Input } from '~/components/ui/input.tsx'
 import { Label } from '~/components/ui/label.tsx'
 import { Checkbox, type CheckboxProps } from '~/components/ui/checkbox.tsx'
 import { Textarea } from '~/components/ui/textarea.tsx'
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from '~/components/ui/popover.tsx'
+import { Button } from '~/components/ui/button.tsx'
+import { Calendar } from '~/components/ui/calendar.tsx'
+import { cn } from '~/utils/misc.ts'
+import { format } from 'date-fns'
+import { Calendar as CalendarIcon } from 'lucide-react'
 
 export type ListOfErrors = Array<string | null | undefined> | null | undefined
 
@@ -49,6 +59,61 @@ export function Field({
 				aria-invalid={errorId ? true : undefined}
 				aria-describedby={errorId}
 				{...inputProps}
+			/>
+			<div className="min-h-[32px] px-4 pb-3 pt-1">
+				{errorId ? <ErrorList id={errorId} errors={errors} /> : null}
+			</div>
+		</div>
+	)
+}
+
+export function DatePickerField({
+	labelProps,
+	errors,
+	className,
+}: {
+	labelProps: Omit<React.LabelHTMLAttributes<HTMLLabelElement>, 'className'>
+	errors?: ListOfErrors
+	className?: string
+}) {
+	const fallbackId = useId()
+	const id = fallbackId
+	const errorId = errors?.length ? `${id}-error` : undefined
+	const [dates, setDates] = React.useState<Date[] | undefined>()
+
+	return (
+		<div className={className}>
+			<Label htmlFor={id} {...labelProps} />
+			<Popover>
+				<PopoverTrigger asChild>
+					<Button
+						variant={'outline'}
+						className={cn(
+							'w-full justify-start text-left font-normal',
+							!dates && 'text-muted-foreground',
+						)}
+					>
+						<CalendarIcon className="mr-2 h-4 w-4 shrink-0" />
+						<span className="overflow-hidden text-ellipsis whitespace-nowrap">
+							{dates
+								? dates.map(date => format(date, 'P')).join(', ')
+								: 'Pick dates'}
+						</span>
+					</Button>
+				</PopoverTrigger>
+				<PopoverContent className="w-auto p-0">
+					<Calendar
+						mode="multiple"
+						selected={dates}
+						onSelect={setDates}
+						initialFocus
+					/>
+				</PopoverContent>
+			</Popover>
+			<input
+				type="hidden"
+				name="dates"
+				value={dates?.map(date => format(date, 'yyyy-MM-dd')).join(', ') ?? ''}
 			/>
 			<div className="min-h-[32px] px-4 pb-3 pt-1">
 				{errorId ? <ErrorList id={errorId} errors={errors} /> : null}

--- a/app/components/listboxes.tsx
+++ b/app/components/listboxes.tsx
@@ -44,7 +44,7 @@ export function HorseListbox({
 			name={name}
 			multiple
 		>
-			<div className="relative mt-1">
+			<div className="relative">
 				<div className={''}>
 					<Listbox.Button
 						className={listboxButtonClassName}
@@ -123,7 +123,7 @@ export function InstructorListbox({
 
 	return (
 		<Listbox value={selected} onChange={setSelected} name={name}>
-			<div className="relative mt-1">
+			<div className="relative">
 				<Listbox.Button className={listboxButtonClassName}>
 					<span className="block truncate">{selected?.name}</span>
 					<span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">

--- a/app/components/ui/calendar.tsx
+++ b/app/components/ui/calendar.tsx
@@ -3,7 +3,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker } from "react-day-picker"
 
 import { cn } from "~/utils/misc.ts"
-import { buttonVariants } from "~/components/ui/button"
+import { buttonVariants } from "~/components/ui/button.tsx"
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>
 

--- a/app/components/ui/calendar.tsx
+++ b/app/components/ui/calendar.tsx
@@ -1,0 +1,62 @@
+import * as React from "react"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import { DayPicker } from "react-day-picker"
+
+import { cn } from "~/utils/misc.ts"
+import { buttonVariants } from "~/components/ui/button"
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        month: "space-y-4",
+        caption: "flex justify-center pt-1 relative items-center",
+        caption_label: "text-sm font-medium",
+        nav: "space-x-1 flex items-center",
+        nav_button: cn(
+          buttonVariants({ variant: "outline" }),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+        ),
+        nav_button_previous: "absolute left-1",
+        nav_button_next: "absolute right-1",
+        table: "w-full border-collapse space-y-1",
+        head_row: "flex",
+        head_cell:
+          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+        row: "flex w-full mt-2",
+        cell: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        day: cn(
+          buttonVariants({ variant: "ghost" }),
+          "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+        ),
+        day_selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        day_today: "bg-accent text-accent-foreground",
+        day_outside: "text-muted-foreground opacity-50",
+        day_disabled: "text-muted-foreground opacity-50",
+        day_range_middle:
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        day_hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
+        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+      }}
+      {...props}
+    />
+  )
+}
+Calendar.displayName = "Calendar"
+
+export { Calendar }

--- a/app/routes/calendar+/$eventId.edit.tsx
+++ b/app/routes/calendar+/$eventId.edit.tsx
@@ -242,7 +242,7 @@ export default function EventEditor() {
 			toast({
 				variant: 'destructive',
 				title:
-					'The following horses are scheduled for cooldown on the selected date:',
+					'The following horses are scheduled for cooldown on the selected dates:',
 				description: actionData.message,
 			})
 		}

--- a/app/routes/calendar+/index.tsx
+++ b/app/routes/calendar+/index.tsx
@@ -691,6 +691,7 @@ function CreateEventForm({
 						</SelectContent>
 					</Select>
 				</div>
+				<Separator className="col-span-2 border" />
 				<div className="col-span-2 sm:col-span-1">
 					<Label htmlFor="horses">Horses</Label>
 					<HorseListbox
@@ -703,7 +704,6 @@ function CreateEventForm({
 					<Label htmlFor="instructor">Instructor</Label>
 					<InstructorListbox name="instructor" instructors={instructors} />
 				</div>
-				<Separator className="col-span-2 border" />
 				<Field
 					className="col-span-2 sm:col-span-1"
 					labelProps={{

--- a/app/routes/calendar+/index.tsx
+++ b/app/routes/calendar+/index.tsx
@@ -140,7 +140,7 @@ const instructorSchema = z
 const createEventSchema = z.object({
 	title: z.string().min(1, 'Title is required'),
 	dates: z.string().regex(new RegExp(/^(\d{4}-\d{2}-\d{2},?\s?)+$/g), 'Invalid dates'),
-	startTime: z.string().regex(new RegExp(/\d{2}:\d{2}/g), 'Invalid start time'),
+	startTime: z.string().regex(new RegExp(/^\d{2}:\d{2}$/g), 'Invalid start time'),
 	duration: z.coerce.number().gt(0),
 	horses: z.array(horseSchema).optional(),
 	instructor: instructorSchema,
@@ -246,19 +246,15 @@ export async function action({ request }: ActionArgs) {
 			}),
 		)
 	}
-	try {
-		await prisma.$transaction(transactions)
-		return json(
-			{
-				status: 'success',
-				submission,
-				message: null,
-			} as const,
-			{ status: 200 },
-		)
-	} catch (e) {
-		console.log(e)
-	}
+	await prisma.$transaction(transactions)
+	return json(
+		{
+			status: 'success',
+			submission,
+			message: null,
+		} as const,
+		{ status: 200 },
+	)
 }
 
 export default function Schedule() {

--- a/app/utils/cooldown-functions.ts
+++ b/app/utils/cooldown-functions.ts
@@ -1,0 +1,42 @@
+import { add, format } from 'date-fns'
+
+interface Horse {
+	id: String
+	name: String
+	cooldownStartDate?: Date | undefined
+	cooldownEndDate?: Date | undefined
+}
+
+export function isCooldownDateConflict(horse: Horse, date: Date) {
+	if (horse.cooldownStartDate && horse.cooldownEndDate) {
+		if (
+			horse.cooldownStartDate <= date &&
+			date < add(horse.cooldownEndDate, { days: 1 })
+		)
+			return true
+	}
+	return false
+}
+
+export function horseDateConflicts(horse: Horse, datesArr: Array<Date>) {
+	let conflictingDatesArr = datesArr.filter(date =>
+		isCooldownDateConflict(horse, date),
+	)
+	if (conflictingDatesArr.length > 0) {
+		return { name: horse.name, conflictingDatesArr }
+	} else return null
+}
+
+export function renderHorseConflictMessage(
+	horseArr: Array<{ name: String; conflictingDatesArr: Array<Date> }>,
+) {
+	let message = ''
+	horseArr.forEach(horse => {
+		const datesString = horse.conflictingDatesArr
+			.sort((a:Date, b:Date) => a.valueOf() - b.valueOf())
+			.map(date => format(date, 'PP'))
+			.join(', ')
+		message = message + `${horse.name} (${datesString}), `
+	})
+	return message.slice(0, -2);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "qrcode": "^1.5.3",
         "react": "^18.2.0",
         "react-big-calendar": "^1.8.1",
+        "react-day-picker": "^8.8.2",
         "react-dom": "^18.2.0",
         "remix-auth": "^3.4.0",
         "remix-auth-form": "^1.3.0",
@@ -16697,6 +16698,19 @@
         "react-dom": "^16.14.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-day-picker": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.8.2.tgz",
+      "integrity": "sha512-sK5M5PNZaLiszmACUKUpVu1eX3eFDVV+WLdWQ3BxTPbEC9jhuawmlgpbSXX5dIIQQwJpZ4wwP5+vsMVOwa1IRw==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "date-fns": "^2.28.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -31881,6 +31895,11 @@
         "react-overlays": "^5.2.1",
         "uncontrollable": "^7.2.1"
       }
+    },
+    "react-day-picker": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.8.2.tgz",
+      "integrity": "sha512-sK5M5PNZaLiszmACUKUpVu1eX3eFDVV+WLdWQ3BxTPbEC9jhuawmlgpbSXX5dIIQQwJpZ4wwP5+vsMVOwa1IRw=="
     },
     "react-dom": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "qrcode": "^1.5.3",
     "react": "^18.2.0",
     "react-big-calendar": "^1.8.1",
+    "react-day-picker": "^8.8.2",
     "react-dom": "^18.2.0",
     "remix-auth": "^3.4.0",
     "remix-auth-form": "^1.3.0",


### PR DESCRIPTION
- Create event forms: Added shadcd.ui datepicker to allow selecting multiple dates. Added time field. 

<img width="566" alt="Screenshot 2023-09-24 at 9 05 23 AM" src="https://github.com/opportunity-hack/evs/assets/92223355/be02ce10-3d98-469f-9272-a19c19845081">

- Updated cooldown check logic to handle multiple dates and render a detailed error message.

![Screen Shot 2023-09-24 at 09 04 39](https://github.com/opportunity-hack/evs/assets/92223355/b84fa912-0bee-42be-9c14-ca562f8aa0fa)

- Create multiple events in single prisma transaction. 

